### PR TITLE
Update CTPanoramaView.swift

### DIFF
--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -33,6 +33,12 @@ import ImageIO
     @objc public var movementHandler: ((_ rotationAngle: CGFloat, _ fieldOfViewAngle: CGFloat) -> Void)?
     @objc public var panSpeed = CGPoint(x: 0.005, y: 0.005)
     @objc public var startAngle: Float = 0
+    
+    @objc public var angleOffset: Float = 0 {
+        didSet {
+            geometryNode?.rotation = SCNQuaternion(0, 1, 0, angleOffset)
+        }
+    }
 
     @objc public var minFoV: CGFloat = 20
     @objc public var maxFoV: CGFloat = 80
@@ -197,6 +203,7 @@ import ImageIO
             tubeNode.geometry = tube
             geometryNode = tubeNode
         }
+        geometryNode?.rotation = SCNQuaternion(0, 1, 0, angleOffset)
         scene.rootNode.addChildNode(geometryNode!)
     }
 


### PR DESCRIPTION
Making changes this way eliminates the need to make messy camera adjustments and prevents the compass from starting at a weird angle. You're basically establishing which way is forward. There could be room to use a quaternion here rather than an angle. I used a float since it better supports cylindrical panoramas and maintains a simpler interface. It would be easy to swap it out though